### PR TITLE
feat(logger): added support to provide service name during logger init

### DIFF
--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -20,7 +20,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             log_record["serviceName"] = self.service_name
 
 
-def getLogger(name, service_name=None):
+def getLogger(name, service_name=None, level=logging.INFO):
     logger = logging.getLogger(name)
 
     # Logs will be written to console
@@ -42,6 +42,6 @@ def getLogger(name, service_name=None):
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    # default level would be INFO
-    logger.setLevel(logging.INFO)
+    # default level would be INFO if level is not provided
+    logger.setLevel(level)
     return logger

--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -8,21 +8,33 @@ __author__ = "deepak.s@safe.security"
 __copyright__ = "Safe Security"
 __license__ = "MIT"
 
+# Adding custom logger to support additional default field such as serviceName
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def __init__(self, *args, **kwargs):
+        self.service_name = kwargs.pop("service_name", None)
+        super().__init__(*args, **kwargs)
 
-def getLogger(name):
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        if (not log_record.get("serviceName")) and self.service_name:
+            log_record["serviceName"] = self.service_name
+
+
+def getLogger(name, service_name=None):
     logger = logging.getLogger(name)
 
     # Logs will be written to console
     console_handler = logging.StreamHandler(sys.stdout)
 
-    formatter = jsonlogger.JsonFormatter(
-        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s ",
+    formatter = CustomJsonFormatter(
+        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s",
         rename_fields={
             "levelname": "level",
             "asctime": "timestamp",
             "funcName": "functionName",
             "name": "loggerName",
         },
+        service_name=service_name,
     )
 
     # Use UTC time


### PR DESCRIPTION
- Added support to provide service name as an optional field during logger init
- If provided, `serviceName` value would be added to all log lines
- Added support for choosing the default log level during init using `level` (Default INFO)


usage: 
- `logging.getLogger("awesome-logger",service_name="mock-service",level="INFO")`