### PR TITLE
feat(logger): added support for additional fields in logger

### DIFF
--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -12,17 +12,24 @@ __license__ = "MIT"
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def __init__(self, *args, **kwargs):
         self.service = kwargs.pop("service", None)
+        self.additional_fields = kwargs.pop("additional_fields", None)
         super().__init__(*args, **kwargs)
 
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
-        if (not log_record.get("service")) and self.service:
-            log_record["service"] = self.service
+        for key, value in self.additional_fields.items():
+            if (not log_record.get(key)) and value:
+                log_record[key] = value
 
 
-def getLogger(name, service=None, level=logging.INFO, handlers=[]):
+def getLogger(
+    name, service=None, level=logging.INFO, handlers=[], additional_fields={}
+):
 
     logger = logging.getLogger(name)
+
+    if service:
+        additional_fields.update({"service": service})
 
     formatter = CustomJsonFormatter(
         "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s",
@@ -33,6 +40,7 @@ def getLogger(name, service=None, level=logging.INFO, handlers=[]):
             "name": "loggerName",
         },
         service=service,
+        additional_fields=additional_fields,
     )
     # Use UTC time
     formatter.converter = time.gmtime


### PR DESCRIPTION
- support to add extra key-value pairs in all log lines using `additional_fields`


usage

`logger = safelogging.getLogger(name="test-log",service="mockService", level="INFO",additional_fields={"test":"hello"})`