### PR TITLE
feat(logger): aded support to move additional fields to metadata

### DIFF
--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -8,7 +8,7 @@ __author__ = "deepak.s@safe.security"
 __copyright__ = "Safe Security"
 __license__ = "MIT"
 
-ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type"]
+ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type", "message"]
 
 # Adding custom logger to support additional default field such as serviceName
 class CustomJsonFormatter(jsonlogger.JsonFormatter):

--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -23,7 +23,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             if (not log_record.get(key)) and value:
                 log_record[key] = value
 
-        # all fields other than the DEFAULT_FIELDS would be moved to the metadata field to maintain consistency with NPM package
+        # all fields other than the root level fields would be moved to the metadata field to maintain consistency with NPM package
         metadata = {}
         log_record_copy = log_record.copy()
         for key, value in log_record_copy.items():

--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -8,11 +8,13 @@ __author__ = "deepak.s@safe.security"
 __copyright__ = "Safe Security"
 __license__ = "MIT"
 
+ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type"]
+
 # Adding custom logger to support additional default field such as serviceName
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def __init__(self, *args, **kwargs):
-        self.service = kwargs.pop("service", None)
         self.additional_fields = kwargs.pop("additional_fields", None)
+        self.root_level_fields = kwargs.pop("root_level_fields", None)
         super().__init__(*args, **kwargs)
 
     def add_fields(self, log_record, record, message_dict):
@@ -21,9 +23,23 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             if (not log_record.get(key)) and value:
                 log_record[key] = value
 
+        # all fields other than the DEFAULT_FIELDS would be moved to the metadata field to maintain consistency with NPM package
+        metadata = {}
+        log_record_copy = log_record.copy()
+        for key, value in log_record_copy.items():
+            if key not in self.root_level_fields:
+                metadata.update({key: value})
+                log_record.pop(key)
+        log_record["metadata"] = metadata
+
 
 def getLogger(
-    name, service=None, level=logging.INFO, handlers=[], additional_fields={}
+    name,
+    service=None,
+    level=logging.INFO,
+    handlers=[],
+    additional_fields={},
+    root_level_fields=ROOT_LEVEL_FIELDS,
 ):
 
     logger = logging.getLogger(name)
@@ -31,16 +47,18 @@ def getLogger(
     if service:
         additional_fields.update({"service": service})
 
+    additional_fields.update({"type": "application"})
+
     formatter = CustomJsonFormatter(
-        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s %(lineno)d",
+        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s",
         rename_fields={
             "levelname": "level",
             "asctime": "timestamp",
             "funcName": "functionName",
             "name": "loggerName",
         },
-        service=service,
         additional_fields=additional_fields,
+        root_level_fields=root_level_fields,
     )
     # Use UTC time
     formatter.converter = time.gmtime

--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -50,7 +50,7 @@ def getLogger(
     additional_fields.update({"type": "application"})
 
     formatter = CustomJsonFormatter(
-        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s",
+        "%(asctime)s %(levelname)s %(message)s %(name)s %(module)s %(funcName)s %(lineno)d",
         rename_fields={
             "levelname": "level",
             "asctime": "timestamp",


### PR DESCRIPTION
- add fields other than `ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type"]` would be moved to `metadata` field to ensure consistency with NPM package (https://github.com/Safe-Security/logger)
- These fields can be configured using the optional argument `root_level_fields` during init