### PR TITLE
feat(logger): add support for requestId and tenantId

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,5 +1,5 @@
 [tool]
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.7.0"
+version = "1.8.0"
 tag_format = "v$version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.8.0 (2025-02-19)
+
+### Feat
+
+- **logger**: add support for tenantId and requestId (#14)
+
 ## v1.7.0 (2022-10-12)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Feat
 
-- **logger**: add support for tenantId and requestId (#14)
+- **logger**: add support for tenantId and requestId (#15)
 
 ## v1.7.0 (2022-10-12)
 

--- a/src/safe_security_logger/logger.py
+++ b/src/safe_security_logger/logger.py
@@ -8,7 +8,7 @@ __author__ = "deepak.s@safe.security"
 __copyright__ = "Safe Security"
 __license__ = "MIT"
 
-ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type", "message", "error"]
+ROOT_LEVEL_FIELDS = ["level", "service", "timestamp", "type", "message", "error", "tenantId", "requestId"]
 
 # Adding custom logger to support additional default field such as serviceName
 class CustomJsonFormatter(jsonlogger.JsonFormatter):


### PR DESCRIPTION
Added tenantId, requestId to python logger to appear at root level to make it consistent with go and nodejs logger. atm for python logs tenantId and requestId are not getting printed at root level. 